### PR TITLE
implement add and remove liquidity txns.

### DIFF
--- a/deridex/__init__.py
+++ b/deridex/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __author__ = "Deridex"

--- a/deridex/perpetuals/v1/perpetual.py
+++ b/deridex/perpetuals/v1/perpetual.py
@@ -602,17 +602,17 @@ class Perpetual:
         if gtx is None:
             gtx = AtomicTransactionComposer()
 
-        global_state = self.global_state["self"]
+        global_state_self = self.global_state["self"]
         if uAsset == self.a1u:
             bAsset = self.a1
-            market_app_id = global_state["a1mk"]
+            market_app_id = global_state_self["a1mk"]
             bAsset_amount = uAsset_amount / (self.global_state["a1mk"]["baer"] / 1e9)
-            supply_share = bAsset_amount * global_state['ta1ss'] / global_state['ta1s']
+            supply_share = bAsset_amount * global_state_self['ta1ss'] / global_state_self['ta1s']
         else:
             bAsset = self.a2
-            market_app_id = global_state["a2mk"]
+            market_app_id = global_state_self["a2mk"]
             bAsset_amount = uAsset_amount / (self.global_state["a2mk"]["baer"] / 1e9)
-            supply_share = bAsset_amount * global_state['ta2ss'] / global_state['ta2s']
+            supply_share = bAsset_amount * global_state_self['ta2ss'] / global_state_self['ta2s']
 
         gtx.add_method_call(
             app_id=self.appId,
@@ -625,9 +625,9 @@ class Perpetual:
                 uAsset,
                 bAsset,
                 market_app_id,
-                global_state["manager"],
-                global_state["af_manager"],
-                global_state["interface"],
+                global_state_self["manager"],
+                global_state_self["af_manager"],
+                global_state_self["interface"],
                 self.vault_addr,
                 int(supply_share),
             ]

--- a/examples/perpetuals/add.py
+++ b/examples/perpetuals/add.py
@@ -1,0 +1,16 @@
+from deridex.perpetuals.v1.client import MainnetClient
+from deridex.perpetuals.v1.account import Account
+from dotenv import dotenv_values
+
+# Create test account
+user_mnemonic = dotenv_values(".env")["mnemonic"]
+user_account = Account(user_mnemonic)
+
+client = MainnetClient(account=user_account)
+# Setup perpetual obj
+perpetual = client.get_perpetual("ALGO/STBL2")
+
+# Get add Txs
+gtx = perpetual.add(1, 10_000, user_account)
+# Submit Tx
+gtx.submit(client.algod)

--- a/examples/perpetuals/remove.py
+++ b/examples/perpetuals/remove.py
@@ -1,0 +1,16 @@
+from deridex.perpetuals.v1.client import MainnetClient
+from deridex.perpetuals.v1.account import Account
+from dotenv import dotenv_values
+
+# Create test account
+user_mnemonic = dotenv_values(".env")["mnemonic"]
+user_account = Account(user_mnemonic)
+
+client = MainnetClient(account=user_account)
+# Setup perpetual obj
+perpetual = client.get_perpetual("ALGO/STBL2")
+
+# Get add Txs
+gtx = perpetual.remove(1, 10_000, user_account)
+# Submit Tx
+gtx.submit(client.algod)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     description="Deridex Derivative Protocol Python SDK",
     author="Deridex",
     author_email="info@deridex.org",
-    version="0.1.2",
+    version="0.1.3",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="MIT",


### PR DESCRIPTION
Is calling `self.update_local_state(account_obj)` the right way to populate `self.vault_addr`? I see `self.vault_addr` being referenced several times, but don't see when it's assigned a value, as `self.update_local_state` isn't called before this PR.

For UX, I wonder if these functions should also accept the symbol strings like `ALGO` or `STBL2`, so the user doesn't have to pass the asset ids.

Should also provide add/remove quotes? Well maybe not for add since that's just the underlying amount, but the remove amount is the bAsset amount. I wasn't sure if the method args for `remove` should be for the uAsset or bAsset. Right now the assetId is the uAsset but the amount is the bAsset.. kinda confusing 😅 